### PR TITLE
Update telco-5g-lab.yaml

### DIFF
--- a/demos/ztp-policygen/site-configs/telco-5g-lab.yaml
+++ b/demos/ztp-policygen/site-configs/telco-5g-lab.yaml
@@ -45,6 +45,7 @@ spec:
           config:
             interfaces:
               - name: ens5f0
+                macAddress: "ac:1f:6b:55:90:20"
                 type: ethernet
                 state: up
                 ipv4:


### PR DESCRIPTION
i was comparing our site config with other config and i found that they tend to put the mac address of the interface under the nodeNetwork.config object.